### PR TITLE
O/p update

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource "aws_iam_role" "default" {
   count                 = var.enabled ? 1 : 0
   name                  = module.labels.id
   assume_role_policy    = var.assume_role_policy
-  managed_policy_arns   = var.managed_policy_arns
+  # managed_policy_arns   = var.managed_policy_arns
   force_detach_policies = var.force_detach_policies
   path                  = var.path
   description           = var.description

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,6 @@ resource "aws_iam_role" "default" {
   count                 = var.enabled ? 1 : 0
   name                  = module.labels.id
   assume_role_policy    = var.assume_role_policy
-  # managed_policy_arns   = var.managed_policy_arns
   force_detach_policies = var.force_detach_policies
   path                  = var.path
   description           = var.description

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,16 +11,16 @@ output "tags" {
 }
 
 output "name" {
-  value = length(aws_iam_role.default) > 0 ? aws_iam_role.default[0].name : null
+  value       = length(aws_iam_role.default) > 0 ? aws_iam_role.default[0].name : null
   description = "Name of specifying the role."
 }
 
 output "policy" {
-  value = length(aws_iam_role_policy.default) > 0 ? aws_iam_role_policy.default[0].policy : null
+  value       = length(aws_iam_role_policy.default) > 0 ? aws_iam_role_policy.default[0].policy : null
   description = "The policy document attached to the role."
 }
 
 output "role" {
-  value = length(aws_iam_role_policy.default) > 0 ? aws_iam_role_policy.default[0].role : null
+  value       = length(aws_iam_role_policy.default) > 0 ? aws_iam_role_policy.default[0].role : null
   description = "The name of the role associated with the policy."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,7 @@
 # Module      : Iam Role
 # Description : Terraform module to create Iam Role resource on AWS.
 output "arn" {
-  value       = aws_iam_role.default[0].arn
+  value       = length(aws_iam_role.default) > 0 ? aws_iam_role.default[0].name : null
   description = "The Amazon Resource Name (ARN) specifying the role."
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,16 +11,16 @@ output "tags" {
 }
 
 output "name" {
-  value       = aws_iam_role.default[0].name
+  value = length(aws_iam_role.default) > 0 ? aws_iam_role.default[0].name : null
   description = "Name of specifying the role."
 }
 
 output "policy" {
-  value       = aws_iam_role_policy.default[0].policy
+  value = length(aws_iam_role_policy.default) > 0 ? aws_iam_role_policy.default[0].policy : null
   description = "The policy document attached to the role."
 }
 
 output "role" {
-  value       = aws_iam_role_policy.default[0].role
+  value = length(aws_iam_role_policy.default) > 0 ? aws_iam_role_policy.default[0].role : null
   description = "The name of the role associated with the policy."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,7 @@
 # Module      : Iam Role
 # Description : Terraform module to create Iam Role resource on AWS.
 output "arn" {
-  value       = length(aws_iam_role.default) > 0 ? aws_iam_role.default[0].name : null
+  value       = length(aws_iam_role.default) > 0 ? aws_iam_role.default[0].arn : null
   description = "The Amazon Resource Name (ARN) specifying the role."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -44,12 +44,6 @@ variable "assume_role_policy" {
   sensitive   = true
   description = "Whether to create Iam role."
 }
-
-variable "managed_policy_arns" {
-  type        = list(any)
-  default     = []
-  description = "Set of exclusive IAM managed policy ARNs to attach to the IAM role"
-}
 variable "force_detach_policies" {
   type        = bool
   default     = false


### PR DESCRIPTION
## what
* Removed the deprecated attribute `managed_policy_arn`.
* Updated the logic of output file for empty values.

## why
* Removed the `managed_policy_arn` attribute it was deprected in new version of terraform.
* Changed the output file login for an empty value because it was giving error.

## references
* Article about this deprecated value [Here](https://github.com/hashicorp/terraform-provider-aws/issues/4426).