### PR TITLE
fix: replace deprecated resource and address aws provider version iss…

### DIFF
--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.31.0"
+      version =  "6.0.0"
     }
   }
 }

--- a/examples/github-oidc/versions.tf
+++ b/examples/github-oidc/versions.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.31.0"
+      version = "6.0.0"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/main.tf
+++ b/main.tf
@@ -20,13 +20,17 @@ resource "aws_iam_role" "default" {
   count                 = var.enabled ? 1 : 0
   name                  = module.labels.id
   assume_role_policy    = var.assume_role_policy
-  managed_policy_arns   = var.managed_policy_arns
   force_detach_policies = var.force_detach_policies
   path                  = var.path
   description           = var.description
   max_session_duration  = var.max_session_duration
   permissions_boundary  = var.permissions_boundary
   tags                  = module.labels.tags
+}
+
+resource "aws_iam_role_policy_attachments_exclusive" "default" {
+  role_name   = aws_iam_role.default[0].id
+  policy_arns = var.managed_policy_arns
 }
 
 ##----------------------------------------------------------------------------- 

--- a/outputs.tf
+++ b/outputs.tf
@@ -16,11 +16,11 @@ output "name" {
 }
 
 output "policy" {
-  value       = aws_iam_role_policy.default[0].policy
+  value       = length(aws_iam_role_policy.default) > 0 ? aws_iam_role_policy.default[0].policy : null
   description = "The policy document attached to the role."
 }
 
 output "role" {
-  value       = aws_iam_role_policy.default[0].role
+  value       = length(aws_iam_role_policy.default) > 0 ? aws_iam_role_policy.default[0].role : null
   description = "The name of the role associated with the policy."
 }


### PR DESCRIPTION
### what

- Replaced the usage of managed_policy_arns with new aws_iam_role_policy_attachment resource using exclusive attachment logic.

- Updated relevant IAM role configurations to support the new exclusive policy attachment approach.
- Replaced the old direct output references to aws_iam_role_policy.default[0] with safe conditional expressions.
- Removed the previous outputs that assumed the policy resource always exists.
- Updated outputs.tf to return null when the optional policy is disabled (i.e., policy_enabled = false).



### why

- Replacing managed_policy_arns with aws_iam_role_policy_attachment (exclusive) provides more control and avoids potential attachment conflicts.
- The earlier output logic caused Terraform to fail with Invalid index errors when the policy_enabled variable was set to false.
- The new conditional output logic ensures the module works correctly even when optional resources are disabled.

### [Reference Docs](https://github.com/hashicorp/terraform-provider-aws/issues/39818)
 